### PR TITLE
1.16.8

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -22,6 +22,9 @@ LET'S fix:
   - Command / Sensors / Strategic?
     - FF, DD, Cruiser, Fleet Cruiser
 
+!IDEA!
+> Have the planetary defense installation techs be one level only, with a basic weapon when unlocked.
+> Then, unlock higher v2, v3... by researching further in the tech that it is based on, instead of a 2nd level of base tech
 
 Cool Ideas:
 - Assault variants

--- a/Notes.txt
+++ b/Notes.txt
@@ -6,14 +6,10 @@ Publish on Steam:
 LET'S fix:
 - Nova missiles
 	- genuinely high dmg / aoe
-- Rail cannons
-	- reduce rof
-	- increase dmg/slug
 - Torps
 	- balance effectiveness on 2nd-wave of them?
-- Shields
-	- power requirements!!
-	- leakiness
+
+- !!Make sensors dependent on countermeasure technologies, and boosted their countermeasure values to be in line with their dependencies !!
 
 ### PROPOSED
 - Specializations
@@ -54,7 +50,7 @@ NULL OUT A RESEARCH PROJECT:
 	</ResearchProjectDefinition>
 
 Gizurean
-	do not have star fighters nor bombers
+	have special hangars (and maybe special fighters)
 	have Mortalen advanced targeting sensors
 
 race-id, name, diplomacy tech (BASIC, EFFECTIVE +1, ADVANCED +2, COMPLETE +3)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ YMMV, but this is my take on making it Extra Large!
 - Removed infantry upgrades from robotic troop techs
 - Better aligned the repeatable techs with XL's tech tree
 - Fixed some repeatable techs' components so they refer to the right things
+- Reduced the size range of habitable planets by -1K
+- Tweaked Proton Engines (Nimble Engines) to be 2x as nimble as the other variants to give them some actual draw to using them
 
 ### v1.16.7
 - Updated for 1.1.6.7 beta (recommended)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 	- [Guiding Principles](#guiding-principles)
 	- [Mod Highlights](#mod-highlights)
 	- [Latest Changes](#latest-changes)
+		- [v1.16.8](#v1168)
 		- [v1.16.7](#v1167)
 		- [v1.16.6](#v1166)
 		- [v1.16.5](#v1165)
@@ -170,6 +171,11 @@ YMMV, but this is my take on making it Extra Large!
   - There are a few endgame facilities that are still one-per-galaxy, but they're not going to stop you or the AI from being competitive when unable to obtain them yourself.
 
 ## Latest Changes
+
+### v1.16.8
+- Removed infantry upgrades from robotic troop techs
+- Better aligned the repeatable techs with XL's tech tree
+- Fixed some repeatable techs' components so they refer to the right things
 
 ### v1.16.7
 - Updated for 1.1.6.7 beta (recommended)

--- a/README.md
+++ b/README.md
@@ -176,8 +176,10 @@ YMMV, but this is my take on making it Extra Large!
 - Removed infantry upgrades from robotic troop techs
 - Better aligned the repeatable techs with XL's tech tree
 - Fixed some repeatable techs' components so they refer to the right things
-- Reduced the size range of habitable planets by -1K
+- Reduced the size range of habitable planets by -1000 (was 4000-6500, now 3000-5500)
 - Tweaked Proton Engines (Nimble Engines) to be 2x as nimble as the other variants to give them some actual draw to using them
+- Changed all hyperdrives to have accuracy of 2000 to try to cope with the BUGGY DW2 ENGINE that tries to jump endless and cannot ever arrive at their destination
+- Tweaked policies to also attempt to address the MASSIVELY BUGGY and BROKEN DW2 that tries to order & build thousands of troops at every mature world
 
 ### v1.16.7
 - Updated for 1.1.6.7 beta (recommended)

--- a/XL/ComponentDefinitions_Dhayut.xml
+++ b/XL/ComponentDefinitions_Dhayut.xml
@@ -98,7 +98,7 @@
 				<HyperDriveJumpRange>160E+06</HyperDriveJumpRange>
 				<HyperDriveRechargeTime>18</HyperDriveRechargeTime>
 				<HyperDriveSpeed>350E+03</HyperDriveSpeed>
-				<HyperDriveJumpAccuracy>1000</HyperDriveJumpAccuracy>
+				<HyperDriveJumpAccuracy>2000</HyperDriveJumpAccuracy>
 				<HyperStopRange>0</HyperStopRange>
 				<HyperStopStrength>0</HyperStopStrength>
 				<IonDamageDefense>0</IonDamageDefense>
@@ -232,7 +232,7 @@
 				<HyperDriveJumpRange>220E+06</HyperDriveJumpRange>
 				<HyperDriveRechargeTime>14</HyperDriveRechargeTime>
 				<HyperDriveSpeed>700E+03</HyperDriveSpeed>
-				<HyperDriveJumpAccuracy>750</HyperDriveJumpAccuracy>
+				<HyperDriveJumpAccuracy>2000</HyperDriveJumpAccuracy>
 				<HyperStopRange>0</HyperStopRange>
 				<HyperStopStrength>0</HyperStopStrength>
 				<IonDamageDefense>0</IonDamageDefense>
@@ -366,7 +366,7 @@
 				<HyperDriveJumpRange>280E+06</HyperDriveJumpRange>
 				<HyperDriveRechargeTime>10</HyperDriveRechargeTime>
 				<HyperDriveSpeed>1400E+03</HyperDriveSpeed>
-				<HyperDriveJumpAccuracy>500</HyperDriveJumpAccuracy>
+				<HyperDriveJumpAccuracy>2000</HyperDriveJumpAccuracy>
 				<HyperStopRange>0</HyperStopRange>
 				<HyperStopStrength>0</HyperStopStrength>
 				<IonDamageDefense>0</IonDamageDefense>
@@ -500,7 +500,7 @@
 				<HyperDriveJumpRange>340E+06</HyperDriveJumpRange>
 				<HyperDriveRechargeTime>6</HyperDriveRechargeTime>
 				<HyperDriveSpeed>2800E+03</HyperDriveSpeed>
-				<HyperDriveJumpAccuracy>250</HyperDriveJumpAccuracy>
+				<HyperDriveJumpAccuracy>2000</HyperDriveJumpAccuracy>
 				<HyperStopRange>0</HyperStopRange>
 				<HyperStopStrength>0</HyperStopStrength>
 				<IonDamageDefense>0</IonDamageDefense>

--- a/XL/OrbTypes.xml
+++ b/XL/OrbTypes.xml
@@ -1245,8 +1245,8 @@
 		<QualityRangeMaximum>1.0</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.192</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.448</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>1</ResourceCountMinimum>
 		<ResourceCountMaximum>4</ResourceCountMaximum>
 		<PossibleResources>
@@ -1442,8 +1442,8 @@
 		<QualityRangeMaximum>1.0</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.192</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.448</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>1</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -1619,8 +1619,8 @@
 		<QualityRangeMaximum>1.0</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.192</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.448</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -1810,8 +1810,8 @@
 		<QualityRangeMaximum>0.9</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.112</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.496</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>2</ResourceCountMaximum>
 		<PossibleResources>
@@ -2002,8 +2002,8 @@
 		<QualityRangeMaximum>0.9</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.752</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>1</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -2184,8 +2184,8 @@
 		<QualityRangeMaximum>0.8</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.048</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.176</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -2347,8 +2347,8 @@
 		<QualityRangeMaximum>0.15</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.102</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.544</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>2</ResourceCountMaximum>
 		<PossibleResources>
@@ -2969,8 +2969,8 @@
 		<QualityRangeMaximum>1.0</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.192</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.448</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>1</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -3142,8 +3142,8 @@
 		<QualityRangeMaximum>1.0</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.192</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.448</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>1</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -3324,8 +3324,8 @@
 		<QualityRangeMaximum>0.9</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.112</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.496</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>2</ResourceCountMaximum>
 		<PossibleResources>
@@ -3492,8 +3492,8 @@
 		<QualityRangeMaximum>0.9</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.112</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.496</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>2</ResourceCountMaximum>
 		<PossibleResources>
@@ -3644,8 +3644,8 @@
 		<QualityRangeMaximum>0.9</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.752</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>1</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -3822,8 +3822,8 @@
 		<QualityRangeMaximum>0.9</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.752</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>1</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -4000,8 +4000,8 @@
 		<QualityRangeMaximum>1.0</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.192</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.448</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -4336,8 +4336,8 @@
 		<QualityRangeMaximum>0.15</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.102</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.544</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>2</ResourceCountMaximum>
 		<PossibleResources>
@@ -4477,8 +4477,8 @@
 		<QualityRangeMaximum>0.2</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.102</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.544</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>0</ResourceCountMinimum>
 		<ResourceCountMaximum>2</ResourceCountMaximum>
 		<PossibleResources>
@@ -4633,8 +4633,8 @@
 		<QualityRangeMaximum>1.0</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.192</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.448</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>1</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -5025,8 +5025,8 @@
 		<QualityRangeMaximum>0.8</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.048</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.236</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>1</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>
@@ -5193,8 +5193,8 @@
 		<QualityRangeMaximum>0.9</QualityRangeMaximum>
 		<OrbitalDistanceFromSunRatioMinimum>0.098</OrbitalDistanceFromSunRatioMinimum>
 		<OrbitalDistanceFromSunRatioMaximum>0.276</OrbitalDistanceFromSunRatioMaximum>
-		<DiameterMinimum>4000</DiameterMinimum>
-		<DiameterMaximum>6500</DiameterMaximum>
+		<DiameterMinimum>3000</DiameterMinimum>
+		<DiameterMaximum>5500</DiameterMaximum>
 		<ResourceCountMinimum>1</ResourceCountMinimum>
 		<ResourceCountMaximum>3</ResourceCountMaximum>
 		<PossibleResources>

--- a/XL/Races.xml
+++ b/XL/Races.xml
@@ -425,12 +425,14 @@
 			<string>Iridium</string>
 			<string>Javelin</string>
 			<string>Juggernaut</string>
+			<string>Khan</string>
 			<string>Katana</string>
 			<string>Khopesh</string>
 			<string>Kukri</string>
 			<string>Kursk</string>
 			<string>Legacy</string>
 			<string>Legionnaires</string>
+			<string>Lightbringer</string>
 			<string>Lunar</string>
 			<string>Marathon</string>
 			<string>Marauder</string>
@@ -490,10 +492,9 @@
 			<string>Solar</string>
 			<string>Solaris</string>
 			<string>Sovereign</string>
-			<string>Space</string>
+			<string>Space Invader</string>
 			<string>Spectre</string>
 			<string>Stalingrad</string>
-			<string>Star</string>
 			<string>Starborn</string>
 			<string>Starfire</string>
 			<string>Starseeker</string>

--- a/XL/ResearchProjectDefinitions.xml
+++ b/XL/ResearchProjectDefinitions.xml
@@ -3159,48 +3159,14 @@
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>75</ResearchProjectId>
-		<Name>Improved Robotics</Name>
+		<!-- <Name>Improved Robotics</Name> -->
+		<Name>Undefined</Name>
 		<ImageFilename>UserInterface/Placeholder</ImageFilename>
-		<Size>900</Size>
-		<InitiationCost>
-			<Money>4500</Money>
-			<Resources>
-				<ResourceQuantity>
-					<ResourceId>9</ResourceId>
-					<Amount>450</Amount>
-				</ResourceQuantity>
-				<ResourceQuantity>
-					<ResourceId>8</ResourceId>
-					<Amount>450</Amount>
-				</ResourceQuantity>
-				<ResourceQuantity>
-					<ResourceId>12</ResourceId>
-					<Amount>450</Amount>
-				</ResourceQuantity>
-			</Resources>
-		</InitiationCost>
-		<EnabledByDefault>true</EnabledByDefault>
-		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
-		<Column>3</Column>
-		<Row>191</Row>
-		<PrerequisiteProjects>
-			<ResearchPath>
-				<ResearchProjectId>22</ResearchProjectId>
-				<PathAppearanceLikelihood>0.9</PathAppearanceLikelihood>
-				<Priority>0</Priority>
-			</ResearchPath>
-		</PrerequisiteProjects>
-		<TroopTechs>
-			<TroopTech>
-				<Type>Infantry</Type>
-				<MaintenanceFactor>0.05</MaintenanceFactor>
-				<RecoveryRateFactor>0.05</RecoveryRateFactor>
-				<AttackStrengthFactor>0.05</AttackStrengthFactor>
-				<DefendStrengthFactor>0.05</DefendStrengthFactor>
-				<SabotageStrengthFactor>0.05</SabotageStrengthFactor>
-				<InterceptWeaponComponentLevelIncrease>0</InterceptWeaponComponentLevelIncrease>
-			</TroopTech>
-		</TroopTechs>
+		<Size>0</Size>
+		<EnabledByDefault>false</EnabledByDefault>
+		<ProjectAppearanceProbability>0</ProjectAppearanceProbability>
+		<Column>0</Column>
+		<Row>0</Row>
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>76</ResearchProjectId>
@@ -6271,36 +6237,14 @@
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>138</ResearchProjectId>
-		<Name>Basic Synthetics</Name>
+		<!-- <Name>Advanced Robotics</Name> -->
+		<Name>Undefined</Name>
 		<ImageFilename>UserInterface/Placeholder</ImageFilename>
-		<Size>5400</Size>
-		<InitiationCost>
-			<Money>12500</Money>
-			<Resources>
-				<ResourceQuantity>
-					<ResourceId>8</ResourceId>
-					<Amount>1250</Amount>
-				</ResourceQuantity>
-				<ResourceQuantity>
-					<ResourceId>78</ResourceId>
-					<Amount>1250</Amount>
-				</ResourceQuantity>
-			</Resources>
-		</InitiationCost>
-		<EnabledByDefault>true</EnabledByDefault>
-		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
-		<Column>5</Column>
-		<Row>191</Row>
-		<PrerequisiteProjects>
-			<ResearchPath>
-				<ResearchProjectId>75</ResearchProjectId>
-				<PathAppearanceLikelihood>0.9</PathAppearanceLikelihood>
-				<Priority>0</Priority>
-			</ResearchPath>
-		</PrerequisiteProjects>
-		<PlanetaryFacilityIds>
-			<short>65</short>
-		</PlanetaryFacilityIds>
+		<Size>0</Size>
+		<EnabledByDefault>false</EnabledByDefault>
+		<ProjectAppearanceProbability>0</ProjectAppearanceProbability>
+		<Column>0</Column>
+		<Row>0</Row>
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>139</ResearchProjectId>
@@ -8968,22 +8912,14 @@
 		<Row>191</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
-				<ResearchProjectId>138</ResearchProjectId>
+				<ResearchProjectId>22</ResearchProjectId>
 				<PathAppearanceLikelihood>0.9</PathAppearanceLikelihood>
 				<Priority>0</Priority>
 			</ResearchPath>
 		</PrerequisiteProjects>
-		<TroopTechs>
-			<TroopTech>
-				<Type>Infantry</Type>
-				<MaintenanceFactor>0.1</MaintenanceFactor>
-				<RecoveryRateFactor>0.1</RecoveryRateFactor>
-				<AttackStrengthFactor>0.1</AttackStrengthFactor>
-				<DefendStrengthFactor>0.1</DefendStrengthFactor>
-				<SabotageStrengthFactor>0.1</SabotageStrengthFactor>
-				<InterceptWeaponComponentLevelIncrease>0</InterceptWeaponComponentLevelIncrease>
-			</TroopTech>
-		</TroopTechs>
+		<PlanetaryFacilityIds>
+			<short>65</short>
+		</PlanetaryFacilityIds>
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>192</ResearchProjectId>
@@ -10139,7 +10075,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>5</Row>
+		<Row>30</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>201</ResearchProjectId>
@@ -10169,8 +10105,8 @@
 		</InitiationCost>
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
-		<Column>13</Column>
-		<Row>0</Row>
+		<Column>11</Column>
+		<Row>31</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>201</ResearchProjectId>
@@ -10202,7 +10138,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>6</Row>
+		<Row>29</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>201</ResearchProjectId>
@@ -10233,7 +10169,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>34</Row>
+		<Row>12</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>204</ResearchProjectId>
@@ -10328,7 +10264,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>16</Row>
+		<Row>62</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>168</ResearchProjectId>
@@ -11236,7 +11172,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>190</Row>
+		<Row>192</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>212</ResearchProjectId>
@@ -25905,9 +25841,9 @@
 		<ResearchProjectId>600</ResearchProjectId>
 		<Name>Galactic Governance</Name>
 		<ImageFilename>UserInterface/Placeholder</ImageFilename>
-		<Size>48600</Size>
+		<Size>72900</Size>
 		<InitiationCost>
-			<Money>32000</Money>
+			<Money>64000</Money>
 			<Resources>
 				<ResourceQuantity>
 					<ResourceId>8</ResourceId>
@@ -25921,7 +25857,7 @@
 		</InitiationCost>
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
-		<Column>9</Column>
+		<Column>10</Column>
 		<Row>323</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
@@ -26328,7 +26264,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>35</Row>
+		<Row>34</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>203</ResearchProjectId>
@@ -26517,7 +26453,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>82</Row>
+		<Row>85</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>210</ResearchProjectId>
@@ -26607,7 +26543,7 @@
 		<Row>204</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
-				<ResearchProjectId>578</ResearchProjectId>
+				<ResearchProjectId>1177</ResearchProjectId>
 				<PathAppearanceLikelihood>1</PathAppearanceLikelihood>
 				<Priority>0</Priority>
 			</ResearchPath>
@@ -26646,7 +26582,7 @@
 		<Row>205</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
-				<ResearchProjectId>578</ResearchProjectId>
+				<ResearchProjectId>1177</ResearchProjectId>
 				<PathAppearanceLikelihood>1</PathAppearanceLikelihood>
 				<Priority>0</Priority>
 			</ResearchPath>
@@ -26682,7 +26618,7 @@
 		<EnabledByDefault>false</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>103</Row>
+		<Row>104</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>581</ResearchProjectId>
@@ -26703,7 +26639,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>104</Row>
+		<Row>103</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>581</ResearchProjectId>
@@ -26820,6 +26756,17 @@
 				<Priority>0</Priority>
 			</ResearchPath>
 		</PrerequisiteProjects>
+		<RepeatableTechLimit>1000</RepeatableTechLimit>
+		<RepeatableComponentValues>
+			<ComponentValues>
+				<ComponentId>306</ComponentId>
+				<Values>
+					<ComponentStats>
+						<HyperDriveEnergyUsage>-0.05</HyperDriveEnergyUsage>
+					</ComponentStats>
+				</Values>
+			</ComponentValues>
+		</RepeatableComponentValues>
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>624</ResearchProjectId>
@@ -26989,7 +26936,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>233</Row>
+		<Row>247</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>586</ResearchProjectId>
@@ -27067,7 +27014,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>237</Row>
+		<Row>246</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>586</ResearchProjectId>
@@ -27293,7 +27240,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>234</Row>
+		<Row>244</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>588</ResearchProjectId>
@@ -27430,7 +27377,7 @@
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>642</ResearchProjectId>
-		<Name>Improved Construction Speed (Construction Yard)</Name>
+		<Name>Improved Construction Speed</Name>
 		<ImageFilename>UserInterface/Placeholder</ImageFilename>
 		<Size>109350</Size>
 		<InitiationCost>
@@ -27442,7 +27389,7 @@
 		<Row>253</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
-				<ResearchProjectId>590</ResearchProjectId>
+				<ResearchProjectId>554</ResearchProjectId>
 				<PathAppearanceLikelihood>1</PathAppearanceLikelihood>
 				<Priority>0</Priority>
 			</ResearchPath>
@@ -27450,7 +27397,7 @@
 		<RepeatableTechLimit>1000</RepeatableTechLimit>
 		<RepeatableComponentValues>
 			<ComponentValues>
-				<ComponentId>196</ComponentId>
+				<ComponentId>556</ComponentId>
 				<Values>
 					<ComponentStats>
 						<ConstructionBuildSpeed>0.05</ConstructionBuildSpeed>
@@ -27461,7 +27408,7 @@
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>643</ResearchProjectId>
-		<Name>Improved Plant Capacity (Construction Yard)</Name>
+		<Name>Improved Construction Capacity</Name>
 		<ImageFilename>UserInterface/Placeholder</ImageFilename>
 		<Size>109350</Size>
 		<InitiationCost>
@@ -27473,7 +27420,7 @@
 		<Row>252</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
-				<ResearchProjectId>590</ResearchProjectId>
+				<ResearchProjectId>554</ResearchProjectId>
 				<PathAppearanceLikelihood>1</PathAppearanceLikelihood>
 				<Priority>0</Priority>
 			</ResearchPath>
@@ -27481,7 +27428,7 @@
 		<RepeatableTechLimit>1000</RepeatableTechLimit>
 		<RepeatableComponentValues>
 			<ComponentValues>
-				<ComponentId>186</ComponentId>
+				<ComponentId>556</ComponentId>
 				<Values>
 					<ComponentStats>
 						<ConstructionYardCount>1</ConstructionYardCount>
@@ -27492,7 +27439,7 @@
 	</ResearchProjectDefinition>
 	<ResearchProjectDefinition>
 		<ResearchProjectId>644</ResearchProjectId>
-		<Name>Improved Max Hull Size (Capital Ships)</Name>
+		<Name>Improved Max Hull Size (Carriers)</Name>
 		<ImageFilename>UserInterface/Placeholder</ImageFilename>
 		<Size>109350</Size>
 		<InitiationCost>
@@ -27501,8 +27448,9 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>259</Row>
+		<Row>258</Row>
 		<PrerequisiteProjects>
+			<!-- colossal carriers -->
 			<ResearchPath>
 				<ResearchProjectId>590</ResearchProjectId>
 				<PathAppearanceLikelihood>1</PathAppearanceLikelihood>
@@ -27511,11 +27459,6 @@
 		</PrerequisiteProjects>
 		<RepeatableTechLimit>1000</RepeatableTechLimit>
 		<RepeatableShipHullValues>
-			<ShipHullValues>
-				<Role>CapitalShip</Role>
-				<Level>3</Level>
-				<MaximumSize>0.05</MaximumSize>
-			</ShipHullValues>
 			<ShipHullValues>
 				<Role>Carrier</Role>
 				<Level>3</Level>
@@ -27555,7 +27498,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>320</Row>
+		<Row>319</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>1170</ResearchProjectId>
@@ -27567,6 +27510,14 @@
 		<RepeatableComponentValues>
 			<ComponentValues>
 				<ComponentId>189</ComponentId>
+				<Values>
+					<ComponentStats>
+						<EnergyFuelProductionRate>0.05</EnergyFuelProductionRate>
+					</ComponentStats>
+				</Values>
+			</ComponentValues>
+			<ComponentValues>
+				<ComponentId>546</ComponentId>
 				<Values>
 					<ComponentStats>
 						<EnergyFuelProductionRate>0.05</EnergyFuelProductionRate>
@@ -27664,7 +27615,7 @@
 		<EnabledByDefault>true</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>289</Row>
+		<Row>281</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>594</ResearchProjectId>
@@ -27726,7 +27677,7 @@
 		<EnabledByDefault>false</EnabledByDefault>
 		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
 		<Column>11</Column>
-		<Row>280</Row>
+		<Row>282</Row>
 		<PrerequisiteProjects>
 			<ResearchPath>
 				<ResearchProjectId>594</ResearchProjectId>

--- a/XL/ResearchProjectDefinitions_XL.xml
+++ b/XL/ResearchProjectDefinitions_XL.xml
@@ -8042,4 +8042,33 @@
 			</Component>
 		</Components>
 	</ResearchProjectDefinition>
+	<ResearchProjectDefinition>
+		<ResearchProjectId>1178</ResearchProjectId>
+		<Name>Improved Max Hull Size (Battleships)</Name>
+		<ImageFilename>UserInterface/Placeholder</ImageFilename>
+		<Size>109350</Size>
+		<InitiationCost>
+			<Money>162000</Money>
+		</InitiationCost>
+		<EnabledByDefault>true</EnabledByDefault>
+		<ProjectAppearanceProbability>1</ProjectAppearanceProbability>
+		<Column>11</Column>
+		<Row>259</Row>
+		<PrerequisiteProjects>
+			<!-- colossal battleships -->
+			<ResearchPath>
+				<ResearchProjectId>1048</ResearchProjectId>
+				<PathAppearanceLikelihood>1</PathAppearanceLikelihood>
+				<Priority>0</Priority>
+			</ResearchPath>
+		</PrerequisiteProjects>
+		<RepeatableTechLimit>1000</RepeatableTechLimit>
+		<RepeatableShipHullValues>
+			<ShipHullValues>
+				<Role>CapitalShip</Role>
+				<Level>3</Level>
+				<MaximumSize>0.05</MaximumSize>
+			</ShipHullValues>
+		</RepeatableShipHullValues>
+	</ResearchProjectDefinition>
 </ArrayOfResearchProjectDefinition>

--- a/XL/mod.json
+++ b/XL/mod.json
@@ -3,7 +3,7 @@
 	"shortDescription": "eXpands and enLarges the game - tech tree, weapons, engines, reactors, sensors, etc.",
 	"descriptionFile": "description.txt",
 	"previewImage": "xl.jpg",
-	"version": "1.16.7",
+	"version": "1.16.8",
 	"bundles": [],
 	"workshopId": 2916197192
 }

--- a/XL/policy/Ackdarian.xml
+++ b/XL/policy/Ackdarian.xml
@@ -196,16 +196,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -229,7 +229,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>

--- a/XL/policy/Boskara.xml
+++ b/XL/policy/Boskara.xml
@@ -196,16 +196,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -229,7 +229,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>

--- a/XL/policy/Dhayut.xml
+++ b/XL/policy/Dhayut.xml
@@ -195,16 +195,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -228,7 +228,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>

--- a/XL/policy/Gizurean.xml
+++ b/XL/policy/Gizurean.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0"?>
 <EmpirePolicy xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<AutomationSettings>
 		<AutomationLevel>Automated</AutomationLevel>
@@ -25,12 +25,12 @@
 		<AutomationLevel>Automated</AutomationLevel>
 		<AutomationLevel>Automated</AutomationLevel>
 	</AutomationSettings>
-	<AttackOvermatchFactor>1.5</AttackOvermatchFactor>
+	<AttackOvermatchFactor>2</AttackOvermatchFactor>
 	<CaptureTargetConditionShip>WhenHighTechOrLargerThanCanBuild</CaptureTargetConditionShip>
-	<CaptureTargetConditionBase>Always</CaptureTargetConditionBase>
+	<CaptureTargetConditionBase>WhenBaseInOwnTerritory</CaptureTargetConditionBase>
 	<CaptureEnlistMilitaryShip>Always</CaptureEnlistMilitaryShip>
 	<CaptureDisassembleMilitaryShip>DisassembleAtBaseWhenHighTechOrLargerThanCanBuildOtherwiseImmediatelyScrapForMoney</CaptureDisassembleMilitaryShip>
-	<CaptureEnlistCivilianShip>WhenNOTHighTechOrLargerThanCanBuild</CaptureEnlistCivilianShip>
+	<CaptureEnlistCivilianShip>Never</CaptureEnlistCivilianShip>
 	<CaptureDisassembleCivilianShip>DisassembleAtBaseWhenHighTechOrLargerThanCanBuildOtherwiseImmediatelyScrapForMoney</CaptureDisassembleCivilianShip>
 	<CaptureEnlistBase>Always</CaptureEnlistBase>
 	<UpgradeEnlistedMilitaryShips>true</UpgradeEnlistedMilitaryShips>
@@ -38,45 +38,29 @@
 	<CharacterHandlingWhenTakeoverShipOrColony>CaptureIfEnemyReturnHomeIfOther</CharacterHandlingWhenTakeoverShipOrColony>
 	<ExecuteCapturedForeignAgents>false</ExecuteCapturedForeignAgents>
 	<Priorities>
-		<BonusPriority>
-			<Type>DamageControl</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
-		<BonusPriority>
-			<Type>BoardingAssault</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
-		<BonusPriority>
-			<Type>ShipMaintenanceAll</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
-		<BonusPriority>
-			<Type>MiningRate</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
 	</Priorities>
 	<ComponentSelectionFactors>
 		<WeaponCloseInFactor>1</WeaponCloseInFactor>
 		<WeaponStandoffFactor>1</WeaponStandoffFactor>
 		<WeaponInterceptFactor>1</WeaponInterceptFactor>
-		<WeaponIonFactor>3</WeaponIonFactor>
+		<WeaponIonFactor>1</WeaponIonFactor>
 		<WeaponBombardFactor>1</WeaponBombardFactor>
-		<WeaponAreaFactor>1.5</WeaponAreaFactor>
+		<WeaponAreaFactor>1</WeaponAreaFactor>
 		<FighterFactor>1</FighterFactor>
 		<ShieldFactor>1</ShieldFactor>
-		<ArmorFactor>1</ArmorFactor>
-		<AssaultPodFactor>2</AssaultPodFactor>
+		<ArmorFactor>1.5</ArmorFactor>
+		<AssaultPodFactor>1.5</AssaultPodFactor>
 		<EngineFactor>1</EngineFactor>
-		<TractorBeamFactor>1.25</TractorBeamFactor>
+		<TractorBeamFactor>1</TractorBeamFactor>
 		<ScannerLongFactor>1</ScannerLongFactor>
 		<ScannerTraceFactor>1</ScannerTraceFactor>
 		<HyperDenyFactor>1</HyperDenyFactor>
 		<HyperStopFactor>1</HyperStopFactor>
 		<CountermeasuresFactor>1</CountermeasuresFactor>
 		<TargetingFactor>1</TargetingFactor>
-		<DamageControlFactor>2</DamageControlFactor>
+		<DamageControlFactor>1</DamageControlFactor>
 		<EngineManeuveringFactor>1</EngineManeuveringFactor>
-		<IonDefenseFactor>2</IonDefenseFactor>
+		<IonDefenseFactor>1</IonDefenseFactor>
 		<StealthFactor>1</StealthFactor>
 		<TroopCompartmentFactor>1</TroopCompartmentFactor>
 		<ConstructionYardFactor>1</ConstructionYardFactor>
@@ -87,34 +71,34 @@
 		<WeaponCloseInDamageAtRangeFactor>1</WeaponCloseInDamageAtRangeFactor>
 		<WeaponCloseInDamageRateFactor>1</WeaponCloseInDamageRateFactor>
 		<WeaponCloseInDamageAtRangeRateFactor>1</WeaponCloseInDamageAtRangeRateFactor>
-		<WeaponCloseInFireRateFactor>2</WeaponCloseInFireRateFactor>
+		<WeaponCloseInFireRateFactor>3</WeaponCloseInFireRateFactor>
 		<WeaponCloseInEnergyUsageFactor>1</WeaponCloseInEnergyUsageFactor>
 		<WeaponStandoffRangeFactor>1</WeaponStandoffRangeFactor>
 		<WeaponStandoffDamageRawFactor>1</WeaponStandoffDamageRawFactor>
 		<WeaponStandoffDamageAtRangeFactor>1</WeaponStandoffDamageAtRangeFactor>
 		<WeaponStandoffDamageRateFactor>1</WeaponStandoffDamageRateFactor>
 		<WeaponStandoffDamageAtRangeRateFactor>1</WeaponStandoffDamageAtRangeRateFactor>
-		<WeaponStandoffFireRateFactor>2</WeaponStandoffFireRateFactor>
+		<WeaponStandoffFireRateFactor>3</WeaponStandoffFireRateFactor>
 		<WeaponStandoffEnergyUsageFactor>1</WeaponStandoffEnergyUsageFactor>
 		<WeaponInterceptRangeFactor>1</WeaponInterceptRangeFactor>
 		<WeaponInterceptDamageFactor>1</WeaponInterceptDamageFactor>
 		<WeaponInterceptDamageRateFactor>1</WeaponInterceptDamageRateFactor>
-		<WeaponInterceptFireRateFactor>1</WeaponInterceptFireRateFactor>
+		<WeaponInterceptFireRateFactor>3</WeaponInterceptFireRateFactor>
 		<WeaponInterceptEnergyUsageFactor>1</WeaponInterceptEnergyUsageFactor>
-		<WeaponIonRangeFactor>1.5</WeaponIonRangeFactor>
-		<WeaponIonEngineDamageFactor>1.5</WeaponIonEngineDamageFactor>
-		<WeaponIonWeaponDamageFactor>1.5</WeaponIonWeaponDamageFactor>
-		<WeaponIonGeneralDamageFactor>1.5</WeaponIonGeneralDamageFactor>
+		<WeaponIonRangeFactor>1</WeaponIonRangeFactor>
+		<WeaponIonEngineDamageFactor>1</WeaponIonEngineDamageFactor>
+		<WeaponIonWeaponDamageFactor>1</WeaponIonWeaponDamageFactor>
+		<WeaponIonGeneralDamageFactor>1</WeaponIonGeneralDamageFactor>
 		<WeaponIonHyperDriveDamageFactor>1</WeaponIonHyperDriveDamageFactor>
 		<WeaponIonSensorDamageFactor>1</WeaponIonSensorDamageFactor>
 		<WeaponIonShieldDamageFactor>1</WeaponIonShieldDamageFactor>
-		<WeaponIonEngineDamageRateFactor>1.5</WeaponIonEngineDamageRateFactor>
+		<WeaponIonEngineDamageRateFactor>1</WeaponIonEngineDamageRateFactor>
 		<WeaponIonHyperDriveDamageRateFactor>1</WeaponIonHyperDriveDamageRateFactor>
 		<WeaponIonSensorDamageRateFactor>1</WeaponIonSensorDamageRateFactor>
 		<WeaponIonShieldDamageRateFactor>1</WeaponIonShieldDamageRateFactor>
-		<WeaponIonWeaponDamageRateFactor>1.5</WeaponIonWeaponDamageRateFactor>
-		<WeaponIonGeneralDamageRateFactor>1.5</WeaponIonGeneralDamageRateFactor>
-		<WeaponIonFireRateFactor>1</WeaponIonFireRateFactor>
+		<WeaponIonWeaponDamageRateFactor>1</WeaponIonWeaponDamageRateFactor>
+		<WeaponIonGeneralDamageRateFactor>1</WeaponIonGeneralDamageRateFactor>
+		<WeaponIonFireRateFactor>3</WeaponIonFireRateFactor>
 		<WeaponIonEnergyUsageFactor>1</WeaponIonEnergyUsageFactor>
 		<WeaponBombardRangeFactor>1</WeaponBombardRangeFactor>
 		<WeaponBombardDamageInfrastructureFactor>1</WeaponBombardDamageInfrastructureFactor>
@@ -127,38 +111,37 @@
 		<WeaponBombardDamageRateQualityFactor>1</WeaponBombardDamageRateQualityFactor>
 		<WeaponBombardFireRateFactor>1</WeaponBombardFireRateFactor>
 		<WeaponBombardEnergyUsageFactor>1</WeaponBombardEnergyUsageFactor>
-		<WeaponAreaRangeFactor>1.5</WeaponAreaRangeFactor>
+		<WeaponAreaRangeFactor>1</WeaponAreaRangeFactor>
 		<WeaponAreaDamageFactor>1</WeaponAreaDamageFactor>
-		<WeaponAreaDamageRateFactor>1.5</WeaponAreaDamageRateFactor>
+		<WeaponAreaDamageRateFactor>1</WeaponAreaDamageRateFactor>
 		<WeaponAreaFireRateFactor>1</WeaponAreaFireRateFactor>
 		<WeaponAreaEnergyUsageFactor>1</WeaponAreaEnergyUsageFactor>
 		<ArmorStrengthFactor>1</ArmorStrengthFactor>
-		<ArmorReactiveFactor>1</ArmorReactiveFactor>
+		<ArmorReactiveFactor>2.5</ArmorReactiveFactor>
 		<ShieldStrengthFactor>1</ShieldStrengthFactor>
-		<ShieldRechargeFactor>1.5</ShieldRechargeFactor>
-		<ShieldResistanceFactor>1.5</ShieldResistanceFactor>
+		<ShieldRechargeFactor>1</ShieldRechargeFactor>
+		<ShieldResistanceFactor>1</ShieldResistanceFactor>
 		<ShieldPenetrationChanceFactor>1</ShieldPenetrationChanceFactor>
 		<ShieldPenetrationRatioFactor>1</ShieldPenetrationRatioFactor>
-		<!-- force it to choose Calista-Dal over Gerax by using energy and range as factors -->
 		<HyperDriveSpeedFactor>1</HyperDriveSpeedFactor>
-		<HyperDriveEnergyUsageFactor>2</HyperDriveEnergyUsageFactor>
-		<HyperDriveJumpRangeFactor>1.5</HyperDriveJumpRangeFactor>
-		<HyperDriveInitiationTimeFactor>0.1</HyperDriveInitiationTimeFactor>
-		<HyperDriveRechargeTimeFactor>0.1</HyperDriveRechargeTimeFactor>
+		<HyperDriveEnergyUsageFactor>1</HyperDriveEnergyUsageFactor>
+		<HyperDriveJumpRangeFactor>1</HyperDriveJumpRangeFactor>
+		<HyperDriveInitiationTimeFactor>3</HyperDriveInitiationTimeFactor>
+		<HyperDriveRechargeTimeFactor>1</HyperDriveRechargeTimeFactor>
 		<AreaShieldRangeFactor>1</AreaShieldRangeFactor>
 		<AreaShieldPowerFactor>1</AreaShieldPowerFactor>
 		<AreaShieldEnergyUsageFactor>1</AreaShieldEnergyUsageFactor>
-		<AssaultPodStrengthFactor>1.5</AssaultPodStrengthFactor>
-		<AssaultPodRangeFactor>1.5</AssaultPodRangeFactor>
+		<AssaultPodStrengthFactor>1</AssaultPodStrengthFactor>
+		<AssaultPodRangeFactor>1</AssaultPodRangeFactor>
 		<AssaultPodEnergyUsageFactor>1</AssaultPodEnergyUsageFactor>
-		<AssaultPodShieldPenetrationFactor>1</AssaultPodShieldPenetrationFactor>
-		<AssaultPodLaunchRateFactor>1</AssaultPodLaunchRateFactor>
+		<AssaultPodShieldPenetrationFactor>1.5</AssaultPodShieldPenetrationFactor>
+		<AssaultPodLaunchRateFactor>1.5</AssaultPodLaunchRateFactor>
 		<AssaultDefenseFactor>1</AssaultDefenseFactor>
-		<DamageReductionFactor>1.5</DamageReductionFactor>
-		<DamageRepairFactor>1.5</DamageRepairFactor>
+		<DamageReductionFactor>1</DamageReductionFactor>
+		<DamageRepairFactor>1</DamageRepairFactor>
 		<DockingBayThroughputFactor>1</DockingBayThroughputFactor>
 		<DockingBayShipCountFactor>1</DockingBayShipCountFactor>
-		<EngineMaximumThrustFactor>1.5</EngineMaximumThrustFactor>
+		<EngineMaximumThrustFactor>1</EngineMaximumThrustFactor>
 		<EngineCruiseThrustFactor>1</EngineCruiseThrustFactor>
 		<EngineEnergyUsageFactor>1</EngineEnergyUsageFactor>
 		<EngineVectoringFactor>1</EngineVectoringFactor>
@@ -182,10 +165,10 @@
 		<ScannerEmpireMaskingFactor>1</ScannerEmpireMaskingFactor>
 		<ScannerRoleMaskingFactor>1</ScannerRoleMaskingFactor>
 		<ReactorOutputFactor>1</ReactorOutputFactor>
-		<ReactorStorageFactor>1</ReactorStorageFactor>
+		<ReactorStorageFactor>3</ReactorStorageFactor>
 		<ReactorFuelUsageFactor>1</ReactorFuelUsageFactor>
-		<TractorBeamPowerFactor>1.5</TractorBeamPowerFactor>
-		<TractorBeamRangeFactor>1.5</TractorBeamRangeFactor>
+		<TractorBeamPowerFactor>1</TractorBeamPowerFactor>
+		<TractorBeamRangeFactor>1</TractorBeamRangeFactor>
 		<TractorBeamEnergyUsageFactor>1</TractorBeamEnergyUsageFactor>
 	</ComponentSelectionFactors>
 	<ExplorationWhenSendSurveyTeam>HiddenItemsPresentOrColonizableOrPopulated</ExplorationWhenSendSurveyTeam>
@@ -209,7 +192,7 @@
 	<CashflowResourceTrading>0</CashflowResourceTrading>
 	<CashflowUncommitted>0.15</CashflowUncommitted>
 	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<AttackTroopLevel>1.5</AttackTroopLevel>
 	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
 	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
 	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
@@ -282,13 +265,13 @@
 		<string></string>
 		<string></string>
 		<string></string>
-		<string>Blasters</string>
+		<string>Rail Guns</string>
 		<!-- CloseIn Weapons -->
-		<string>Missiles</string>
+		<string></string>
 		<!-- Standoff Weapons -->
 		<string></string>
 		<!-- Ion Weapons -->
-		<string>Missiles</string>
+		<string>Rail Guns</string>
 		<!-- Intercept Weapons -->
 		<string></string>
 		<!-- Bombard Weapons -->

--- a/XL/policy/Haakonish.xml
+++ b/XL/policy/Haakonish.xml
@@ -196,16 +196,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -229,7 +229,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>

--- a/XL/policy/Human.xml
+++ b/XL/policy/Human.xml
@@ -196,16 +196,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -229,7 +229,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>

--- a/XL/policy/Ikkuro.xml
+++ b/XL/policy/Ikkuro.xml
@@ -200,16 +200,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -233,7 +233,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>

--- a/XL/policy/Mortalen.xml
+++ b/XL/policy/Mortalen.xml
@@ -196,16 +196,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -229,7 +229,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>

--- a/XL/policy/Quameno.xml
+++ b/XL/policy/Quameno.xml
@@ -27,7 +27,7 @@
 	</AutomationSettings>
 	<AttackOvermatchFactor>1.5</AttackOvermatchFactor>
 	<CaptureTargetConditionShip>WhenHighTechOrLargerThanCanBuild</CaptureTargetConditionShip>
-	<CaptureTargetConditionBase>Always</CaptureTargetConditionBase>
+	<CaptureTargetConditionBase>WhenBaseInOwnTerritory</CaptureTargetConditionBase>
 	<CaptureEnlistMilitaryShip>Always</CaptureEnlistMilitaryShip>
 	<CaptureDisassembleMilitaryShip>DisassembleAtBaseWhenHighTechOrLargerThanCanBuildOtherwiseImmediatelyScrapForMoney</CaptureDisassembleMilitaryShip>
 	<CaptureEnlistCivilianShip>WhenNOTHighTechOrLargerThanCanBuild</CaptureEnlistCivilianShip>
@@ -38,45 +38,29 @@
 	<CharacterHandlingWhenTakeoverShipOrColony>CaptureIfEnemyReturnHomeIfOther</CharacterHandlingWhenTakeoverShipOrColony>
 	<ExecuteCapturedForeignAgents>false</ExecuteCapturedForeignAgents>
 	<Priorities>
-		<BonusPriority>
-			<Type>DamageControl</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
-		<BonusPriority>
-			<Type>BoardingAssault</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
-		<BonusPriority>
-			<Type>ShipMaintenanceAll</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
-		<BonusPriority>
-			<Type>MiningRate</Type>
-			<Priority>1.5</Priority>
-		</BonusPriority>
 	</Priorities>
 	<ComponentSelectionFactors>
 		<WeaponCloseInFactor>1</WeaponCloseInFactor>
 		<WeaponStandoffFactor>1</WeaponStandoffFactor>
 		<WeaponInterceptFactor>1</WeaponInterceptFactor>
-		<WeaponIonFactor>3</WeaponIonFactor>
+		<WeaponIonFactor>1</WeaponIonFactor>
 		<WeaponBombardFactor>1</WeaponBombardFactor>
-		<WeaponAreaFactor>1.5</WeaponAreaFactor>
+		<WeaponAreaFactor>1</WeaponAreaFactor>
 		<FighterFactor>1</FighterFactor>
 		<ShieldFactor>1</ShieldFactor>
 		<ArmorFactor>1</ArmorFactor>
-		<AssaultPodFactor>2</AssaultPodFactor>
+		<AssaultPodFactor>1</AssaultPodFactor>
 		<EngineFactor>1</EngineFactor>
-		<TractorBeamFactor>1.25</TractorBeamFactor>
+		<TractorBeamFactor>1</TractorBeamFactor>
 		<ScannerLongFactor>1</ScannerLongFactor>
 		<ScannerTraceFactor>1</ScannerTraceFactor>
 		<HyperDenyFactor>1</HyperDenyFactor>
 		<HyperStopFactor>1</HyperStopFactor>
 		<CountermeasuresFactor>1</CountermeasuresFactor>
 		<TargetingFactor>1</TargetingFactor>
-		<DamageControlFactor>2</DamageControlFactor>
+		<DamageControlFactor>1</DamageControlFactor>
 		<EngineManeuveringFactor>1</EngineManeuveringFactor>
-		<IonDefenseFactor>2</IonDefenseFactor>
+		<IonDefenseFactor>1</IonDefenseFactor>
 		<StealthFactor>1</StealthFactor>
 		<TroopCompartmentFactor>1</TroopCompartmentFactor>
 		<ConstructionYardFactor>1</ConstructionYardFactor>
@@ -87,33 +71,33 @@
 		<WeaponCloseInDamageAtRangeFactor>1</WeaponCloseInDamageAtRangeFactor>
 		<WeaponCloseInDamageRateFactor>1</WeaponCloseInDamageRateFactor>
 		<WeaponCloseInDamageAtRangeRateFactor>1</WeaponCloseInDamageAtRangeRateFactor>
-		<WeaponCloseInFireRateFactor>2</WeaponCloseInFireRateFactor>
+		<WeaponCloseInFireRateFactor>1</WeaponCloseInFireRateFactor>
 		<WeaponCloseInEnergyUsageFactor>1</WeaponCloseInEnergyUsageFactor>
 		<WeaponStandoffRangeFactor>1</WeaponStandoffRangeFactor>
 		<WeaponStandoffDamageRawFactor>1</WeaponStandoffDamageRawFactor>
 		<WeaponStandoffDamageAtRangeFactor>1</WeaponStandoffDamageAtRangeFactor>
 		<WeaponStandoffDamageRateFactor>1</WeaponStandoffDamageRateFactor>
 		<WeaponStandoffDamageAtRangeRateFactor>1</WeaponStandoffDamageAtRangeRateFactor>
-		<WeaponStandoffFireRateFactor>2</WeaponStandoffFireRateFactor>
+		<WeaponStandoffFireRateFactor>1</WeaponStandoffFireRateFactor>
 		<WeaponStandoffEnergyUsageFactor>1</WeaponStandoffEnergyUsageFactor>
 		<WeaponInterceptRangeFactor>1</WeaponInterceptRangeFactor>
 		<WeaponInterceptDamageFactor>1</WeaponInterceptDamageFactor>
 		<WeaponInterceptDamageRateFactor>1</WeaponInterceptDamageRateFactor>
 		<WeaponInterceptFireRateFactor>1</WeaponInterceptFireRateFactor>
 		<WeaponInterceptEnergyUsageFactor>1</WeaponInterceptEnergyUsageFactor>
-		<WeaponIonRangeFactor>1.5</WeaponIonRangeFactor>
-		<WeaponIonEngineDamageFactor>1.5</WeaponIonEngineDamageFactor>
-		<WeaponIonWeaponDamageFactor>1.5</WeaponIonWeaponDamageFactor>
-		<WeaponIonGeneralDamageFactor>1.5</WeaponIonGeneralDamageFactor>
+		<WeaponIonRangeFactor>1</WeaponIonRangeFactor>
+		<WeaponIonEngineDamageFactor>1</WeaponIonEngineDamageFactor>
+		<WeaponIonWeaponDamageFactor>1</WeaponIonWeaponDamageFactor>
+		<WeaponIonGeneralDamageFactor>1</WeaponIonGeneralDamageFactor>
 		<WeaponIonHyperDriveDamageFactor>1</WeaponIonHyperDriveDamageFactor>
 		<WeaponIonSensorDamageFactor>1</WeaponIonSensorDamageFactor>
 		<WeaponIonShieldDamageFactor>1</WeaponIonShieldDamageFactor>
-		<WeaponIonEngineDamageRateFactor>1.5</WeaponIonEngineDamageRateFactor>
+		<WeaponIonEngineDamageRateFactor>1</WeaponIonEngineDamageRateFactor>
 		<WeaponIonHyperDriveDamageRateFactor>1</WeaponIonHyperDriveDamageRateFactor>
 		<WeaponIonSensorDamageRateFactor>1</WeaponIonSensorDamageRateFactor>
 		<WeaponIonShieldDamageRateFactor>1</WeaponIonShieldDamageRateFactor>
-		<WeaponIonWeaponDamageRateFactor>1.5</WeaponIonWeaponDamageRateFactor>
-		<WeaponIonGeneralDamageRateFactor>1.5</WeaponIonGeneralDamageRateFactor>
+		<WeaponIonWeaponDamageRateFactor>1</WeaponIonWeaponDamageRateFactor>
+		<WeaponIonGeneralDamageRateFactor>1</WeaponIonGeneralDamageRateFactor>
 		<WeaponIonFireRateFactor>1</WeaponIonFireRateFactor>
 		<WeaponIonEnergyUsageFactor>1</WeaponIonEnergyUsageFactor>
 		<WeaponBombardRangeFactor>1</WeaponBombardRangeFactor>
@@ -127,16 +111,16 @@
 		<WeaponBombardDamageRateQualityFactor>1</WeaponBombardDamageRateQualityFactor>
 		<WeaponBombardFireRateFactor>1</WeaponBombardFireRateFactor>
 		<WeaponBombardEnergyUsageFactor>1</WeaponBombardEnergyUsageFactor>
-		<WeaponAreaRangeFactor>1.5</WeaponAreaRangeFactor>
+		<WeaponAreaRangeFactor>1</WeaponAreaRangeFactor>
 		<WeaponAreaDamageFactor>1</WeaponAreaDamageFactor>
-		<WeaponAreaDamageRateFactor>1.5</WeaponAreaDamageRateFactor>
+		<WeaponAreaDamageRateFactor>1</WeaponAreaDamageRateFactor>
 		<WeaponAreaFireRateFactor>1</WeaponAreaFireRateFactor>
 		<WeaponAreaEnergyUsageFactor>1</WeaponAreaEnergyUsageFactor>
 		<ArmorStrengthFactor>1</ArmorStrengthFactor>
 		<ArmorReactiveFactor>1</ArmorReactiveFactor>
-		<ShieldStrengthFactor>1</ShieldStrengthFactor>
-		<ShieldRechargeFactor>1.5</ShieldRechargeFactor>
-		<ShieldResistanceFactor>1.5</ShieldResistanceFactor>
+		<ShieldStrengthFactor>5</ShieldStrengthFactor>
+		<ShieldRechargeFactor>0.5</ShieldRechargeFactor>
+		<ShieldResistanceFactor>1</ShieldResistanceFactor>
 		<ShieldPenetrationChanceFactor>1</ShieldPenetrationChanceFactor>
 		<ShieldPenetrationRatioFactor>1</ShieldPenetrationRatioFactor>
 		<!-- force it to choose Calista-Dal over Gerax by using energy and range as factors -->
@@ -148,17 +132,17 @@
 		<AreaShieldRangeFactor>1</AreaShieldRangeFactor>
 		<AreaShieldPowerFactor>1</AreaShieldPowerFactor>
 		<AreaShieldEnergyUsageFactor>1</AreaShieldEnergyUsageFactor>
-		<AssaultPodStrengthFactor>1.5</AssaultPodStrengthFactor>
-		<AssaultPodRangeFactor>1.5</AssaultPodRangeFactor>
+		<AssaultPodStrengthFactor>1</AssaultPodStrengthFactor>
+		<AssaultPodRangeFactor>1</AssaultPodRangeFactor>
 		<AssaultPodEnergyUsageFactor>1</AssaultPodEnergyUsageFactor>
 		<AssaultPodShieldPenetrationFactor>1</AssaultPodShieldPenetrationFactor>
 		<AssaultPodLaunchRateFactor>1</AssaultPodLaunchRateFactor>
 		<AssaultDefenseFactor>1</AssaultDefenseFactor>
-		<DamageReductionFactor>1.5</DamageReductionFactor>
-		<DamageRepairFactor>1.5</DamageRepairFactor>
+		<DamageReductionFactor>1</DamageReductionFactor>
+		<DamageRepairFactor>1</DamageRepairFactor>
 		<DockingBayThroughputFactor>1</DockingBayThroughputFactor>
 		<DockingBayShipCountFactor>1</DockingBayShipCountFactor>
-		<EngineMaximumThrustFactor>1.5</EngineMaximumThrustFactor>
+		<EngineMaximumThrustFactor>1</EngineMaximumThrustFactor>
 		<EngineCruiseThrustFactor>1</EngineCruiseThrustFactor>
 		<EngineEnergyUsageFactor>1</EngineEnergyUsageFactor>
 		<EngineVectoringFactor>1</EngineVectoringFactor>
@@ -183,9 +167,9 @@
 		<ScannerRoleMaskingFactor>1</ScannerRoleMaskingFactor>
 		<ReactorOutputFactor>1</ReactorOutputFactor>
 		<ReactorStorageFactor>1</ReactorStorageFactor>
-		<ReactorFuelUsageFactor>1</ReactorFuelUsageFactor>
-		<TractorBeamPowerFactor>1.5</TractorBeamPowerFactor>
-		<TractorBeamRangeFactor>1.5</TractorBeamRangeFactor>
+		<ReactorFuelUsageFactor>3</ReactorFuelUsageFactor>
+		<TractorBeamPowerFactor>1</TractorBeamPowerFactor>
+		<TractorBeamRangeFactor>1</TractorBeamRangeFactor>
 		<TractorBeamEnergyUsageFactor>1</TractorBeamEnergyUsageFactor>
 	</ComponentSelectionFactors>
 	<ExplorationWhenSendSurveyTeam>HiddenItemsPresentOrColonizableOrPopulated</ExplorationWhenSendSurveyTeam>
@@ -201,13 +185,13 @@
 	<TaxRateTargetApprovalSmallColonies>40</TaxRateTargetApprovalSmallColonies>
 	<TaxRateTargetApprovalMediumColonies>20</TaxRateTargetApprovalMediumColonies>
 	<TaxRateTargetApprovalLargeColonies>5</TaxRateTargetApprovalLargeColonies>
-	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
-	<CashflowResearchFunding>0.3</CashflowResearchFunding>
+	<CashflowColonyGrowthFunding>0.5</CashflowColonyGrowthFunding>
+	<CashflowResearchFunding>0.5</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.2</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.2</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<CashflowUncommitted>0.3</CashflowUncommitted>
 	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
 	<AttackTroopLevel>0.5</AttackTroopLevel>
 	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
@@ -284,11 +268,11 @@
 		<string></string>
 		<string>Blasters</string>
 		<!-- CloseIn Weapons -->
-		<string>Missiles</string>
+		<string>Torpedoes</string>
 		<!-- Standoff Weapons -->
 		<string></string>
 		<!-- Ion Weapons -->
-		<string>Missiles</string>
+		<string>Blasters</string>
 		<!-- Intercept Weapons -->
 		<string></string>
 		<!-- Bombard Weapons -->

--- a/XL/policy/Zenox.xml
+++ b/XL/policy/Zenox.xml
@@ -192,16 +192,16 @@
 	<CashflowColonyGrowthFunding>0.7</CashflowColonyGrowthFunding>
 	<CashflowResearchFunding>0.3</CashflowResearchFunding>
 	<CashflowStateShipMaintenance>0.6</CashflowStateShipMaintenance>
-	<CashflowTroopMaintenance>0.3</CashflowTroopMaintenance>
-	<CashflowFacilityMaintenance>0.1</CashflowFacilityMaintenance>
+	<CashflowTroopMaintenance>0.05</CashflowTroopMaintenance>
+	<CashflowFacilityMaintenance>0.30</CashflowFacilityMaintenance>
 	<CashflowResourceTrading>0</CashflowResourceTrading>
-	<CashflowUncommitted>0.1</CashflowUncommitted>
-	<ColonyTroopGarrisonLevel>1</ColonyTroopGarrisonLevel>
-	<AttackTroopLevel>1</AttackTroopLevel>
-	<ConstructionSpaceportLargePopulationRequired>5E+09</ConstructionSpaceportLargePopulationRequired>
-	<ConstructionSpaceportMediumPopulationRequired>2E+09</ConstructionSpaceportMediumPopulationRequired>
-	<ConstructionSpaceportSmallPopulationRequired>0.2E+09</ConstructionSpaceportSmallPopulationRequired>
-	<ConstructionSpaceportNearestDistance>5E+03</ConstructionSpaceportNearestDistance>
+	<CashflowUncommitted>0.15</CashflowUncommitted>
+	<ColonyTroopGarrisonLevel>0.5</ColonyTroopGarrisonLevel>
+	<AttackTroopLevel>0.5</AttackTroopLevel>
+	<ConstructionSpaceportLargePopulationRequired>10E+09</ConstructionSpaceportLargePopulationRequired>
+	<ConstructionSpaceportMediumPopulationRequired>5E+09</ConstructionSpaceportMediumPopulationRequired>
+	<ConstructionSpaceportSmallPopulationRequired>250E+03</ConstructionSpaceportSmallPopulationRequired>
+	<ConstructionSpaceportNearestDistance>0</ConstructionSpaceportNearestDistance>
 	<ConstructionLevelSpaceport>1</ConstructionLevelSpaceport>
 	<ConstructionLevelDefensiveBases>0.5</ConstructionLevelDefensiveBases>
 	<ConstructionLevelMonitoring>0.5</ConstructionLevelMonitoring>
@@ -225,7 +225,7 @@
 	<MilitaryShipMissionRatioPatrol>0.5</MilitaryShipMissionRatioPatrol>
 	<MilitaryShipMissionRatioRaid>0</MilitaryShipMissionRatioRaid>
 	<EngageInTourism>true</EngageInTourism>
-	<ColonizationMinimumSuitability>0.10</ColonizationMinimumSuitability>
+	<ColonizationMinimumSuitability>0.01</ColonizationMinimumSuitability>
 	<IntelligenceMissionCounterIntelRatio>0.34</IntelligenceMissionCounterIntelRatio>
 	<IntelligenceMissionAggressiveness>1</IntelligenceMissionAggressiveness>
 	<IntelligenceMissionCaution>1</IntelligenceMissionCaution>


### PR DESCRIPTION
- Removed infantry upgrades from robotic troop techs
- Better aligned the repeatable techs with XL's tech tree
- Fixed some repeatable techs' components so they refer to the right things
- Reduced the size range of habitable planets by -1000 (was 4000-6500, now 3000-5500)
- Tweaked Proton Engines (Nimble Engines) to be 2x as nimble as the other variants to give them some actual draw to using them
- Changed all hyperdrives to have accuracy of 2000 to try to cope with the BUGGY DW2 ENGINE that tries to jump endless and cannot ever arrive at their destination
- Tweaked policies to also attempt to address the MASSIVELY BUGGY and BROKEN DW2 that tries to order & build thousands of troops at every mature world
